### PR TITLE
Output Cleanup

### DIFF
--- a/bin/tic_tac_toe
+++ b/bin/tic_tac_toe
@@ -2,12 +2,9 @@
 require 'curses'
 require File.expand_path('../../lib/tic_tac_toe', __FILE__)
 
-STATUS_LINE = 10
 
-def write(line, column, text)
-  Curses.setpos(line, column)
-  Curses.addstr(text);
-end
+STATUS_LINE = 10
+STATUS_LINE_LENGTH = 23
 
 def init_screen
   Curses.noecho # do not show typed keys
@@ -20,21 +17,33 @@ def init_screen
   end
 end
 
+def write(line, column, text)
+  Curses.setpos(line, column)
+  Curses.addstr(text);
+end
+
+
 def display(ttt)
-  Curses.clear
-  write(STATUS_LINE+1, 0, "q=Quit r=Reset a=AI-move")
   write 0,0,ttt.board
   if winner = ttt.winner
-    write(STATUS_LINE, 0, "Player #{winner} has won!!!!")
+    status("Player #{winner} has won!!!!")
   elsif ttt.draw?
-    write(STATUS_LINE, 0, "It is a draw...")
+    status("It is a draw...")
   else
-    write(STATUS_LINE, 0, "It is #{ttt.player}`s turn...")
+    status("It is #{ttt.player}`s turn...")
   end
+end
+
+def status(message)
+	# pad the status with spaces to replace old characters
+	message += " " * (STATUS_LINE_LENGTH - message.length)
+	write(STATUS_LINE, 0, message)
 end
 
 init_screen do
   ttt = TicTacToe.new
+  
+  write(STATUS_LINE+1, 0, "q=Quit r=Reset a=AI-move")
 
   loop do
     display ttt

--- a/bin/tic_tac_toe
+++ b/bin/tic_tac_toe
@@ -21,6 +21,8 @@ def init_screen
 end
 
 def display(ttt)
+  Curses.clear
+  write(STATUS_LINE+1, 0, "q=Quit r=Reset a=AI-move")
   write 0,0,ttt.board
   if winner = ttt.winner
     write(STATUS_LINE, 0, "Player #{winner} has won!!!!")
@@ -32,8 +34,6 @@ def display(ttt)
 end
 
 init_screen do
-  write(STATUS_LINE+1, 0, "q=Quit r=Reset a=AI-move")
-
   ttt = TicTacToe.new
 
   loop do

--- a/bin/tic_tac_toe
+++ b/bin/tic_tac_toe
@@ -35,9 +35,9 @@ def display(ttt)
 end
 
 def status(message)
-	# pad the status with spaces to replace old characters
-	message += " " * (STATUS_LINE_LENGTH - message.length)
-	write(STATUS_LINE, 0, message)
+  # pad the status with spaces to replace old characters
+  message += " " * (STATUS_LINE_LENGTH - message.length)
+  write(STATUS_LINE, 0, message)
 end
 
 init_screen do


### PR DESCRIPTION
Added a call to Curses.clear in display() to prevent out-of-place leftover characters from being displayed, and moved a write() call from main to display(), so that the user will still be presented with control information after the screen is redrawn.
